### PR TITLE
Fix issue with empty redcap_repeating_instrument field while saving; …

### DIFF
--- a/Child.php
+++ b/Child.php
@@ -124,10 +124,10 @@ class Child
         }
 
         //if redcap_repeat_instrument and redcap_repeat_instance are blank then strip them.
-        if ($record['redcap_repeat_instrument'] == '') {
+        if ((isset($record['redcap_repeat_instrument'])) && ($record['redcap_repeat_instrument'] == '')) {
             unset($record['redcap_repeat_instrument']);
 
-            if ($record['redcap_repeat_instance'] == '') {
+            if ((isset($record['redcap_repeat_instance'])) && ($record['redcap_repeat_instance'] == '')) {
                 unset($record['redcap_repeat_instance']);
             }
         }

--- a/Child.php
+++ b/Child.php
@@ -123,6 +123,15 @@ class Child
             $record[$config['child-field-for-migration-timestamp']] = date('Y-m-d H:i:s');
         }
 
+        //if redcap_repeat_instrument and redcap_repeat_instance are blank then strip them.
+        if ($record['redcap_repeat_instrument'] == '') {
+            unset($record['redcap_repeat_instrument']);
+
+            if ($record['redcap_repeat_instance'] == '') {
+                unset($record['redcap_repeat_instance']);
+            }
+        }
+
         $this->setRecord($record);
         //$this->emLog($newData, "SAVING THIS TO CHILD DATA");
 
@@ -171,7 +180,7 @@ class Child
 
         // Check for upload errors
         if (!empty($result['errors'])) {
-            return $result['errors'];
+            return $result['errors']; // this is a string, not an array
         } else {
             /**
              * let check if parent record is in a DAG, if so lets find the corresponding Child DAG and update the data accordingly

--- a/MirrorMasterDataModule.php
+++ b/MirrorMasterDataModule.php
@@ -515,7 +515,14 @@ class MirrorMasterDataModule extends \ExternalModules\AbstractExternalModule
             $result = $this->getChild()->saveData($config, $this->getMaster(),
                 $this->getProjectSetting('child-save-record-hook'),
                 $this->getFirstEventId($this->getChild()->getProjectId()), $this->getDagId());
-            if (is_array($result)) {
+
+            //if (is_array($result)) {
+            //3 possible returns for result:
+            //  1. Error string if error while saving (not an array)
+            //  2. false if fails while handling a dag
+            //  3. true if passes
+            //report error if anything but a pass
+            if ($result !== true) {
                 $msg = "Error creating record in CHILD project " . $this->getChild()->getProjectId() . " - ask administrator to review logs: " . print_r($result,
                         true);
                 $this->emError($msg);


### PR DESCRIPTION
…fix error reporting when child fails save

1. strip off redcap_repeating_insrument and repeating_instance when blank (otherwise these cause save to fail for non repeating forms)
2. Failed save in child was not bubbling up to parent (and erroneously reporting success in migration)